### PR TITLE
Fix links rendering for some edge cases

### DIFF
--- a/howdoyou.el
+++ b/howdoyou.el
@@ -358,11 +358,7 @@ a, img or pre. Otherwise just copy"
       (concat "+" (dom-texts it) "+"))
      ((and (equal (car it) 'a)
            (not (dom-by-tag it 'img))) ;; bail out if img
-      (concat "[["
-              (dom-attr it 'href)
-              "]["
-              (dom-texts it)
-              "]]"))
+      (org-make-link-string (dom-attr it 'href) (dom-texts it)))
      ;; ((and (equal (dom-tag it) 'div)
      ;;       (equal (dom-attr it 'class) "snippet"))
      ;;  (mapcar #'howdoyou--it-to-it (dom-by-tag it 'pre)))


### PR DESCRIPTION
E.g. when the text of a link contains `[]` symbols.
Steps to reproduce:
1. `(setq howdoyou-number-of-answers 10)`
2. search for "How do I check whether a file exists without exceptions"
3. jump to the heading "Answer (222)" 
There are many links with a text like this: [Python 3]: os.path.exists(path) 
They are rendered poorly:
`[[https://docs.python.org/3/library/os.path.html#os.path.exists][[Python 3]: os.path. exists ( path )]]`
After this change, they will be rendered properly: 
`{Python 3}: os.path. exists ( path )`
