### PR TITLE
Prev or next past the error link

### DIFF
--- a/howdoyou.el
+++ b/howdoyou.el
@@ -231,10 +231,10 @@ URL is a link string. Download the url and parse it to a DOM object"
         (erase-buffer)
         (insert (if msg
                     (apply #'format msg args)
-                  "Searching..."))
-        (read-only-mode 1)
-        (unless howdoyou-mode
-          (howdoyou-mode 1))))))
+                  "Searching...")))
+      (read-only-mode 1)
+      (unless howdoyou-mode
+        (howdoyou-mode 1)))))
 
 (defun howdoyou-promise-answer (query)
   "Process QUERY and print answers to *How Do You* buffer."


### PR DESCRIPTION
Previously, if link is in error, there was no way to skip past it.