### PR TITLE
Inform about 3rd party requirement for counsel example

### DIFF
--- a/README.org
+++ b/README.org
@@ -57,6 +57,8 @@ Now =helm-google-suggest= will pass suggestion to howdoyou-query as default
 action.
 
 * Use with counsel-web-suggest
+Requires installed and configured [[https://github.com/mnewt/counsel-web][counsel-web-suggest]]
+
 add this function definition to your config file
 #+begin_src elisp
   (defun my/howdoyou-with-suggestions ()

--- a/README.org
+++ b/README.org
@@ -57,7 +57,7 @@ Now =helm-google-suggest= will pass suggestion to howdoyou-query as default
 action.
 
 * Use with counsel-web-suggest
-Requires installed and configured [[https://github.com/mnewt/counsel-web][counsel-web-suggest]]
+Requires installed and configured 3rd party package [[https://github.com/mnewt/counsel-web][counsel-web]].
 
 add this function definition to your config file
 #+begin_src elisp


### PR DESCRIPTION
As opposite to `helm-google-suggest`, `counsel-web-suggest` isn't part of official abo-abo's ivy/counsel package and needs to be installed separately.

Without this notice users could get confused.

edit: I've missed this fact in my previous PR.