### PR TITLE
howdoyou-single-buffer: option to not re-use output buffer

### DIFF
--- a/howdoyou.el
+++ b/howdoyou.el
@@ -224,7 +224,8 @@ URL is a link string. Download the url and parse it to a DOM object"
         (get-buffer-create (or (and (buffer-name)
                                     (string-match (regexp-quote name) (buffer-name))
                                     (current-buffer))
-                               (buffer-live-p howdoyou--current-buffer)
+                               (and (buffer-live-p howdoyou--current-buffer)
+                                    howdoyou--current-buffer)
                                name))
        (generate-new-buffer name)))))
 


### PR DESCRIPTION
+ This feature is useful for not 'losing' a potentially useful result
  while scanning for others, and for comparing results side-by-side.

+ Creates defcustom howdoyou-single-buffer

+ Creates defvar howdoyou--current-buffer

+ Removes 'let' from function howdoyou--print-waiting-message

+ Adds ability to over-ride the defcustom at run-time, using a
  prefix-arg

There is a follow-on feature 'multi-query', but it only makes sense
for multiple howdoyou buffers, ie. after merging this PR.