### PR TITLE
Multi query

### DIFF
--- a/howdoyou.el
+++ b/howdoyou.el
@@ -224,7 +224,8 @@ URL is a link string. Download the url and parse it to a DOM object"
         (get-buffer-create (or (and (buffer-name)
                                     (string-match (regexp-quote name) (buffer-name))
                                     (current-buffer))
-                               (buffer-live-p howdoyou--current-buffer)
+                               (and (buffer-live-p howdoyou--current-buffer)
+                                    howdoyou--current-buffer)
                                name))
        (generate-new-buffer name)))))
 

--- a/howdoyou.el
+++ b/howdoyou.el
@@ -113,22 +113,22 @@ This can be over-ridden at run-time by using a PREFIX-ARG."
   :group 'howdoyou)
 
 ;; private variables
-(defvar howdoyou--current-link-index 0
+(defvar-local howdoyou--current-link-index 0
   "Current index of link.")
 
-(defvar howdoyou--links nil
+(defvar-local howdoyou--links nil
   "List of so links from google search.")
 
-(defvar howdoyou--query-history '()
+(defvar-local howdoyou--query-history '()
   "List of query history")
 
-(defvar howdoyou--current-lang nil
+(defvar-local howdoyou--current-lang nil
   "Guested language.")
 
-(defvar howdoyou--current-user-agent 0
+(defvar-local howdoyou--current-user-agent 0
   "Index to be rotated.")
 
-(defvar howdoyou--google-link-class "^yuRUbf$"
+(defvar-local howdoyou--google-link-class "^yuRUbf$"
   "css class name of dom node that has <a href></a> node as a child.")
 
 ;; (setq howdoyou--google-link-class "^yuRUbf$")


### PR DESCRIPTION
+ This feature is useful for not 'losing' a potentially useful result
  while scanning for others, and for comparing results side-by-side.

+ Creates defcustom howdoyou-single-buffer

+ Creates defvar howdoyou--current-buffer

+ Removes 'let' from function howdoyou--print-waiting-message

+ Adds ability to over-ride the defcustom at run-time, using a
  prefix-arg

There is a follow-on feature 'multi-query', but it only makes sense
for multiple howdoyou buffers, ie. after merging PR#20